### PR TITLE
SMTP error when saving email settings

### DIFF
--- a/lib/action_mailer_configs_interceptor.rb
+++ b/lib/action_mailer_configs_interceptor.rb
@@ -23,7 +23,7 @@ module ActionMailerConfigsInterceptor
     if email_configs
       message.delivery_method(:smtp, build_smtp_configs_hash(email_configs))
 
-      message.from = "#{email_configs.account.name} <#{email_configs.value['from_email']}>"
+      message.from = email_configs.value['from_email']
     else
       message.delivery_method(:test)
     end


### PR DESCRIPTION
When I save email settings, the following error is displayed:

> 553-5.1.7 The sender address <Fluxs> is not a valid RFC 5321 address. Please [...]

Without this commit, everything works normally. I think the variable "message.from" is the sending email and not "{Name} <{Email}>"