### PR TITLE
Add bash script to run everything through overmind or foreman

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if ! command -v foreman &> /dev/null
+then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+foreman start -f Procfile.dev "$@"

--- a/bin/dev
+++ b/bin/dev
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
-if ! command -v foreman &> /dev/null
-then
-  echo "Installing foreman..."
-  gem install foreman
+if command -v overmind &> /dev/null; then
+  overmind start -f Procfile.dev "$@"
+else
+  foreman start -f Procfile.dev "$@"
 fi
-
-foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
This PR allows developers to run `bin/dev` from the command line, which in turn starts all the services defined in the `Procfile.dev` located at the project's root directory. It checks for the presence of `Overmind` and uses `Foreman` as a fallback if not found.