### PR TITLE
Introducing DocuSeal Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@
   <a href="https://twitter.com/intent/follow?screen_name=docusealco">
     <img src="https://img.shields.io/twitter/follow/docusealco?style=social" alt="Follow @docusealco" />
   </a>
+  <a href="https://gurubase.io/g/docuseal">
+    <img src="https://img.shields.io/badge/Gurubase-Ask%20DocuSeal%20Guru-006BFF" alt="Ask DocuSeal Guru" />
+  </a>
 </p>
 <p>
 DocuSeal is an open source platform that provides secure and efficient digital document signing and processing. Create PDF forms to have them filled and signed online on any device with an easy-to-use, mobile-optimized web tool.


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [DocuSeal Guru](https://gurubase.io/g/docuseal) to Gurubase. DocuSeal Guru uses the data from this repo and data from the [docs](https://www.docuseal.com/) to answer questions by leveraging the LLM.

In this PR, I showcased the "DocuSeal Guru", which highlights that DocuSeal now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable DocuSeal Guru in Gurubase, just let me know that's totally fine.
