### PR TITLE
expose version via /api/version

### DIFF
--- a/app/controllers/api/version_controller.rb
+++ b/app/controllers/api/version_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Api
+  class VersionController < ApiBaseController
+    skip_before_action :authenticate_user!
+    skip_authorization_check
+
+    def show
+      render json: { version: Docuseal.version }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,7 @@ Rails.application.routes.draw do
       resources :form_events, only: %i[index], path: 'form/:type'
       resources :submission_events, only: %i[index], path: 'submission/:type'
     end
+    get 'version', to: 'version#show'
   end
 
   resources :verify_pdf_signature, only: %i[create]


### PR DESCRIPTION
I thought it would be handy to be able to easily get a server's version. Maybe this would be generally useful for that purpose, or perhaps as a no-auth-required health check? What do you think?

FWIW, my personal motivation is to be able to easily create a [Docuseal tile for Homer](https://github.com/bastienwirtz/homer/blob/main/docs/customservices.md).