### PR TITLE
Improve German translation of signing page

### DIFF
--- a/config/locales/i18n.yml
+++ b/config/locales/i18n.yml
@@ -3645,7 +3645,7 @@ de: &de
   or: oder
   download_documents: Dokumente herunterladen
   downloading: Lädt herunter
-  download: Laden
+  download: Download
   decline: Ablehnen
   declined: Abgelehnt
   decline_reason: Ablehnungsgrund


### PR DESCRIPTION
"Laden" is not a good translation of "Download".
"Download" itself is better, much more frequently used and will be perfectly understood by any German, Austrian or Swiss using Docuseal from any side (author, signer, reviewer, auditer, ...).

The only truly German alternative would be "Herunterladen", which would work too but is longer, a bit stiff and not better understood.