### PR TITLE
feat: carry forward font and alignment attributes for new fields

### DIFF
--- a/app/controllers/templates_preferences_controller.rb
+++ b/app/controllers/templates_preferences_controller.rb
@@ -57,7 +57,8 @@ class TemplatesPreferencesController < ApplicationController
                       require_all_submitters submitters_order require_phone_2fa require_email_2fa
                       default_expire_at_duration shared_link_2fa default_expire_at request_email_enabled
                       completed_notification_email_subject completed_notification_email_body
-                      completed_notification_email_enabled completed_notification_email_attach_audit] +
+                      completed_notification_email_enabled completed_notification_email_attach_audit
+                      carry_forward_attributes] +
                       [completed_message: %i[title body],
                        submitters: [%i[uuid request_email_subject request_email_body]], link_form_fields: []]
     ).tap do |attrs|

--- a/app/javascript/template_builder/builder.vue
+++ b/app/javascript/template_builder/builder.vue
@@ -1210,6 +1210,21 @@ export default {
         }
       }
 
+      const lastField = this.selectedField || this.template.fields[this.template.fields.length - 1]
+
+      if (this.template.preferences?.carry_forward_attributes && lastField?.preferences) {
+        field.preferences ||= {}
+        field.preferences = { ...field.preferences }
+
+        const attrsToCopy = ['font', 'font_size', 'font_type', 'align', 'valign', 'color']
+
+        attrsToCopy.forEach((attr) => {
+          if (lastField.preferences[attr]) {
+            field.preferences[attr] = lastField.preferences[attr]
+          }
+        })
+      }
+
       if (field.type === 'strikethrough') {
         field.readonly = true
         field.default_value = true
@@ -1254,6 +1269,21 @@ export default {
         }
 
         this.drawField = field
+
+        const lastField = this.selectedField || this.template.fields[this.template.fields.length - 1]
+
+        if (this.template.preferences?.carry_forward_attributes && lastField?.preferences) {
+          field.preferences ||= {}
+          field.preferences = { ...field.preferences }
+
+          const attrsToCopy = ['font', 'font_size', 'font_type', 'align', 'valign', 'color']
+
+          attrsToCopy.forEach((attr) => {
+            if (lastField.preferences[attr]) {
+              field.preferences[attr] = lastField.preferences[attr]
+            }
+          })
+        }
       }
 
       this.drawOption = null

--- a/app/views/templates_preferences/show.html.erb
+++ b/app/views/templates_preferences/show.html.erb
@@ -89,6 +89,14 @@
                 <%= ff.check_box :require_email_2fa, { checked: ff.object.require_email_2fa == true, class: 'toggle' }, 'true', 'false' %>
               </submit-form>
             </div>
+            <div class="flex items-center justify-between py-2.5 px-1 mb-2">
+              <span>
+                <%= t('carry_forward_field_attributes_on_the_document') %>
+              </span>
+              <submit-form data-on="change" class="flex">
+                <%= ff.check_box :carry_forward_attributes, { checked: ff.object.carry_forward_attributes == true, class: 'toggle' }, 'true', 'false' %>
+              </submit-form>
+            </div>
           <% end %>
           <div class="form-control pt-2">
             <%= f.button button_title(title: t('save'), disabled_with: t('saving')), class: 'base-button' %>


### PR DESCRIPTION
### What
When adding a new field, font size, font style and alignment are now inherited
from the previously created field to reduce repetitive manual configuration.

### Why
Most documents use consistent field styling. Carrying forward these attributes
improves consistency, reduces errors and saves time.

### How
- Reuse styling attributes from the last active field
- (Optional) Add a form preference toggle to enable/disable this behavior
