### PR TITLE
dotenv: only switch to uid 2000 when running as root

### DIFF
--- a/config/dotenv.rb
+++ b/config/dotenv.rb
@@ -60,7 +60,7 @@ if ENV['RAILS_ENV'] == 'production'
     ENV['DATABASE_URL'] = ENV['DATABASE_URL'].to_s.empty? ? database_url : ENV.fetch('DATABASE_URL', nil)
   end
 
-  unless Process.euid == 2000
+  if Process.uid.zero? && Process.euid != 2000
     begin
       test_file = "#{ENV.fetch('WORKDIR', '.')}/test"
 


### PR DESCRIPTION
Non-root processes cannot switch to uid/gid 2000 and may crash under
strict seccomp filters when setxid syscalls are blocked. Keep the switch
logic for root-run/container setups (e.g. Synology ACL case).
