### PR TITLE
Add Company Logo Upload Support for Free Plan

### DIFF
--- a/app/controllers/logos_controller.rb
+++ b/app/controllers/logos_controller.rb
@@ -1,0 +1,25 @@
+class LogosController < ApplicationController
+  def create
+    authorize! :update, current_account
+
+    current_account.logo.attach(logo_params[:logo])
+
+    redirect_back fallback_location: settings_personalization_path,
+                  notice: I18n.t('settings_have_been_saved')
+  end
+
+  def destroy
+    authorize! :update, current_account
+
+    current_account.logo.purge
+
+    redirect_back fallback_location: settings_personalization_path,
+                  notice: I18n.t('settings_have_been_saved')
+  end
+
+  private
+
+  def logo_params
+    params.require(:account_logo).permit(:logo)
+  end
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -50,6 +50,7 @@ class Account < ApplicationRecord
   has_many :testing_accounts, through: :account_testing_accounts, source: :linked_account
   has_many :active_users, -> { active }, dependent: :destroy,
                                          inverse_of: :account, class_name: 'User'
+  has_one_attached :logo
 
   attribute :timezone, :string, default: 'UTC'
   attribute :locale, :string, default: 'en-US'

--- a/app/views/accounts/_logo.html.erb
+++ b/app/views/accounts/_logo.html.erb
@@ -1,0 +1,4 @@
+<%= image_tag url_for(current_account.logo),
+    class: "h-10 object-contain",
+    alt: current_account.name.presence || "Company Logo" %>
+<span><%= current_account.name %></span>

--- a/app/views/personalization_settings/_logo_dropzone.html.erb
+++ b/app/views/personalization_settings/_logo_dropzone.html.erb
@@ -1,0 +1,58 @@
+<%= form_for '', url: account_logo_path, id: form_id = SecureRandom.uuid, method: :post,
+    class: 'mt-8 block', html: { enctype: 'multipart/form-data' } do %>
+
+  <input type="hidden" name="form_id" value="<%= form_id %>">
+  <button type="submit" class="hidden"></button>
+
+  <file-dropzone data-submit-on-upload="true" class="w-full">
+    <label for="logo_dropzone_input"
+      class="w-full block h-40 relative hover:bg-base-200/30 rounded-xl border-2 border-base-300 border-dashed"
+      data-target="file-dropzone.area">
+
+      <div class="absolute inset-0 flex items-center justify-center p-2 pointer-events-none">
+        <div class="flex flex-col items-center text-center">
+
+          <!-- Upload State -->
+          <span data-target="file-dropzone.icon" class="flex flex-col items-center mb-3">
+            <span>
+              <%= svg_icon('cloud_upload', class: 'w-8 h-8') %>
+            </span>
+
+            <div class="font-medium mb-1">
+              <%= t('upload_logo') %>
+            </div>
+
+            <div class="text-sm">
+              <%= t('click_to_upload_or_drag_and_drop_html') %>
+            </div>
+
+            <div class="text-xs opacity-60 mt-1">
+              PNG, JPG, SVG
+            </div>
+          </span>
+
+          <!-- Loading State -->
+          <span data-target="file-dropzone.loading" class="flex flex-col items-center hidden">
+            <%= svg_icon('loader', class: 'w-8 h-8 animate-spin') %>
+            <div class="font-medium mb-1">
+              <%= t('uploading') %>...
+            </div>
+          </span>
+
+        </div>
+
+        <!-- Input -->
+        <input
+          id="logo_dropzone_input"
+          name="account_logo[logo]"
+          class="hidden"
+          data-action="change:file-dropzone#onSelectFiles"
+          data-target="file-dropzone.input"
+          type="file"
+          accept="image/*"
+        >
+      </div>
+    </label>
+  </file-dropzone>
+
+<% end %>

--- a/app/views/personalization_settings/_logo_form.html.erb
+++ b/app/views/personalization_settings/_logo_form.html.erb
@@ -1,1 +1,5 @@
-<%= render 'logo_placeholder' %>
+<% if !Docuseal.multitenant? || can?(:manage, :personalization_advanced) %>
+  <%= render 'logo_upload_form' %>
+<% else %>
+  <%= render 'logo_placeholder' %>
+<% end %>

--- a/app/views/personalization_settings/_logo_upload_form.html.erb
+++ b/app/views/personalization_settings/_logo_upload_form.html.erb
@@ -1,0 +1,27 @@
+<div class="my-6">
+  <div class="flex flex-col items-center gap-4 mb-6">
+    <div class="flex items-center justify-center w-32 h-20 bg-base-200 rounded-lg border border-base-300">
+      <% if current_account.logo.attached? %>
+        <%= image_tag url_for(current_account.logo),
+            class: "max-h-16 max-w-full object-contain" %>
+      <% else %>
+        <div class="flex flex-col items-center text-base-content/50 p-4">
+          <%= svg_icon('photo', class: 'w-6 h-6 mb-1') %>
+          <span class="text-xs">No logo</span>
+        </div>
+      <% end %>
+    </div>
+    <% if current_account.logo.attached? %>
+      <%= button_to account_logo_path,
+          method: :delete,
+          class: "btn btn-outline btn-error btn-sm normal-case",
+          form_class: "inline-block" do %>
+        <%= svg_icon('trash', class: 'w-4 h-4 mr-1') %>
+        <span><%= t("remove_logo") %></span>
+      <% end %>
+    <% end %>
+
+  </div>
+
+  <%= render 'logo_dropzone' %>
+</div>

--- a/app/views/shared/_title.html.erb
+++ b/app/views/shared/_title.html.erb
@@ -1,2 +1,6 @@
-<%= render 'shared/logo' %>
-<span>DocuSeal</span>
+<% if current_account&.logo&.attached? %>
+  <%= render 'accounts/logo' %>
+<% else %>
+  <%= render 'shared/logo' %>
+  <span>DocuSeal</span>
+<% end %>

--- a/config/locales/i18n.yml
+++ b/config/locales/i18n.yml
@@ -322,6 +322,7 @@ en: &en
   button_title: Button title
   button_url: Button URL
   upload_logo: Upload Logo
+  remove_logo: Remove Logo
   show_confetti_on_successful_completion: Show confetti on successful completion
   attach_audit_log_pdf: Attach audit log PDF
   attach_documents: Attach documents

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@
 
 Rails.application.routes.draw do
   mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
+  mount ActiveStorage::Engine => "/rails/active_storage"
 
   if !Docuseal.multitenant? && defined?(Sidekiq::Web)
     authenticated :user, ->(u) { u.sidekiq? } do
@@ -50,6 +51,7 @@ Rails.application.routes.draw do
     end
   end
 
+  resource :account_logo, controller: 'logos', only: [:create, :destroy]
   resources :verify_pdf_signature, only: %i[create]
   resource :mfa_setup, only: %i[show new edit create destroy], controller: 'mfa_setup'
   resources :account_configs, only: %i[create destroy]


### PR DESCRIPTION
## Summary

This PR adds support for uploading and displaying a company logo for accounts using ActiveStorage.

## Changes

- Added logo upload functionality using ActiveStorage
- Implemented drag-and-drop upload UI (Dropzone)
- Added logo display in header
- Added remove logo functionality
- Improved UI with placeholder and better styling

## Technical Details

- Uses `has_one_attached :logo` in Account model
- No additional DB column required
- Uses existing ActiveStorage setup
- Compatible with current multi-tenant setup

## Screenshots
### Before

<img width="2098" height="1624" alt="image" src="https://github.com/user-attachments/assets/b57e0fdb-fd99-4965-9378-bf65aa7ea9bf" />


### After
<img width="2300" height="1648" alt="image" src="https://github.com/user-attachments/assets/ce5d9095-b866-45e6-94ad-e03aa089d3ff" />

## Notes

- This feature enables logo upload for free plan users
- This feature follows the ACL, only permitted user can upload the logo
- Does not affect existing paid features