### PR TITLE
fix: use account-level "Send from Email" setting over SMTP_FROM env var

### DIFF
--- a/lib/action_mailer_configs_interceptor.rb
+++ b/lib/action_mailer_configs_interceptor.rb
@@ -15,18 +15,6 @@ module ActionMailerConfigsInterceptor
       return message
     end
 
-    if Rails.env.production? && Rails.application.config.action_mailer.delivery_method
-      from = ENV.fetch('SMTP_FROM').to_s.split(',').sample
-
-      if from.match?(User::FULL_EMAIL_REGEXP)
-        message[:from] = message[:from].to_s.sub(User::EMAIL_REGEXP, from)
-      else
-        message.from = from
-      end
-
-      return message
-    end
-
     unless Docuseal.multitenant?
       email_configs = EncryptedConfig.order(:account_id).find_by(key: EncryptedConfig::EMAIL_SMTP_KEY)
 
@@ -34,9 +22,27 @@ module ActionMailerConfigsInterceptor
         message.delivery_method(:smtp, build_smtp_configs_hash(email_configs))
 
         message.from = %("#{email_configs.account.name.to_s.delete('"')}" <#{email_configs.value['from_email']}>)
-      else
-        message.delivery_method(:test)
+
+        return message
       end
+    end
+
+    if Rails.application.config.action_mailer.delivery_method
+      from = ENV.fetch('SMTP_FROM', '').to_s.split(',').sample
+
+      if from.present?
+        if from.match?(User::FULL_EMAIL_REGEXP)
+          message[:from] = message[:from].to_s.sub(User::EMAIL_REGEXP, from)
+        else
+          message.from = from
+        end
+      end
+
+      return message
+    end
+
+    unless Docuseal.multitenant?
+      message.delivery_method(:test)
     end
 
     message


### PR DESCRIPTION
## Problem

The "Send from Email" field configured in Settings > Email is ignored when SMTP delivery is also configured at the Rails level (via env vars). Emails are sent from the SMTP username instead of the configured from address.

This happens because the `SMTP_FROM` env var early-return path in `ActionMailerConfigsInterceptor#delivering_email` runs **before** the account-level DB config lookup, so the UI setting never gets a chance to apply.

## Fix

Move the account-level DB config check (`EncryptedConfig` lookup) before the `SMTP_FROM` env var fallback. When an account has configured SMTP settings via the UI (including "Send from Email"), those settings now take precedence. `SMTP_FROM` env var still works as a fallback when no account-level config exists.

Also changed `ENV.fetch('SMTP_FROM')` to `ENV.fetch('SMTP_FROM', '')` to avoid `KeyError` when the env var is unset and no DB config is present.

### Priority order (after this fix):
1. Account-level SMTP config from DB (Settings > Email) — highest priority
2. `SMTP_FROM` env var — fallback
3. Test delivery — no config at all

## Before / After

**Before:** `delivering_email` checks `SMTP_FROM` env var first → returns early → DB `from_email` never consulted.

**After:** `delivering_email` checks DB `from_email` first → uses it if present → falls back to `SMTP_FROM` env var.

Fixes #598