### PR TITLE
Fix open redirect in templates share link controller

### DIFF
--- a/app/controllers/templates_share_link_controller.rb
+++ b/app/controllers/templates_share_link_controller.rb
@@ -10,7 +10,7 @@ class TemplatesShareLinkController < ApplicationController
 
     @template.update!(template_params)
 
-    if params[:redir].present?
+    if params[:redir].present? && params[:redir].start_with?('/')
       redirect_to params[:redir]
     else
       head :ok


### PR DESCRIPTION
The `create` action in `TemplatesShareLinkController` passes `params[:redir]` directly to `redirect_to` without any validation.

An authenticated user with template update permissions can craft a URL like:
```
/templates/123/share_link?redir=https://evil.com
```

This will redirect to an arbitrary external URL after updating the template shared link settings. Open redirects are useful for phishing attacks where an attacker constructs a link that appears to point to a trusted domain but actually sends the victim elsewhere.

**Fix:** Only allow relative paths (starting with `/`) as redirect targets. External URLs are rejected.