### PR TITLE
Fix open redirect in sessions controller after login

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -27,8 +27,6 @@ class SessionsController < Devise::SessionsController
   def after_sign_in_path_for(...)
     if params[:redir].present?
       return console_redirect_index_path(redir: params[:redir]) if params[:redir].starts_with?(Docuseal::CONSOLE_URL)
-
-      return params[:redir]
     end
 
     super


### PR DESCRIPTION
The `after_sign_in_path_for` method in `SessionsController` has a logic issue that allows open redirects after login.

Current logic:
```ruby
if params[:redir].starts_with?(Docuseal::CONSOLE_URL)
  return console_redirect_index_path(redir: params[:redir])
end

return params[:redir]  # <-- any non-console URL is returned directly
```

The intent was to only allow console URLs, but the else branch returns the user-supplied `redir` param as-is for any URL that isn't the console URL. An attacker can craft:
```
/users/sign_in?redir=https://evil.com
```

After successful login, the user is redirected to `evil.com`.

**Fix:** Remove the else branch so non-console URLs fall through to `super` (Devise's default behavior).