### PR TITLE
Fix: Add authorization check to attachments upload endpoint

### DIFF
--- a/app/controllers/api/attachments_controller.rb
+++ b/app/controllers/api/attachments_controller.rb
@@ -10,7 +10,7 @@ module Api
     def create
       submitter = Submitter.find_by!(slug: params[:submitter_slug])
 
-      unless can_upload?(submitter)
+      unless can_upload?(submitter) && authorized_for_form?(submitter)
         Rollbar.error("Can't upload: #{submitter.id}") if defined?(Rollbar)
 
         return render json: { error: I18n.t('form_has_been_archived') }, status: :unprocessable_content
@@ -44,6 +44,12 @@ module Api
       Rollbar.error(e) if defined?(Rollbar)
 
       render json: { error: e.message }, status: :unprocessable_content
+    end
+
+    private
+
+    def authorized_for_form?(submitter)
+      Submitters::AuthorizedForForm.call(submitter, nil, request)
     end
 
     def can_upload?(submitter)


### PR DESCRIPTION
The `/api/attachments` endpoint has no authentication or authorization checks. Anyone who knows a submitter slug can upload arbitrary files (including signatures/initials) to that submitter.

All other form-facing endpoints (`SubmitFormController`, `SubmitFormDownloadController`, `SubmitFormMetadataController`, etc.) check `Submitters::AuthorizedForForm` before allowing actions. This endpoint was the exception.

Impact: An attacker with a leaked submitter slug could inject attachments (e.g. forged signatures) before the legitimate submitter completes the form.

Fix: Added the same `AuthorizedForForm` check used by other public form endpoints. When 2FA is enabled (email/phone), the attacker would also need to pass that check.

Note: The slug is 14-char base58 (not brute-forceable), so practical risk is low — but the defense-in-depth check should still be there for consistency.