### PR TITLE
Fix open redirect in TemplatesShareLinkController

### DIFF
--- a/app/controllers/templates_share_link_controller.rb
+++ b/app/controllers/templates_share_link_controller.rb
@@ -10,7 +10,7 @@ class TemplatesShareLinkController < ApplicationController
 
     @template.update!(template_params)
 
-    if params[:redir].present?
+    if params[:redir].present? && params[:redir].start_with?('/')
       redirect_to params[:redir]
     else
       head :ok


### PR DESCRIPTION
The `create` action in `TemplatesShareLinkController` redirects to `params[:redir]` without any validation. This allows an authenticated attacker to craft a URL like:

```
/templates/123/share_link?template[shared_link]=true&redir=https://evil.com
```

which redirects the victim to an external site. Could be used for phishing after login.

Fix: Only allow relative paths (starting with `/`).