### PR TITLE
Harden SSRF protection in DownloadUtils

### DIFF
--- a/lib/download_utils.rb
+++ b/lib/download_utils.rb
@@ -31,6 +31,18 @@ module DownloadUtils
     'ip6-allrouters'
   ].freeze
 
+  BLOCKED_CIDRS = [
+    IPAddr.new('10.0.0.0/8'),
+    IPAddr.new('172.16.0.0/12'),
+    IPAddr.new('192.168.0.0/16'),
+    IPAddr.new('127.0.0.0/8'),
+    IPAddr.new('169.254.0.0/16'),
+    IPAddr.new('100.64.0.0/10'),
+    IPAddr.new('::1/128'),
+    IPAddr.new('fc00::/7'),
+    IPAddr.new('fe80::/10')
+  ].freeze
+
   UnableToDownload = Class.new(StandardError)
 
   module_function
@@ -55,6 +67,24 @@ module DownloadUtils
     raise UnableToDownload, "Error loading: #{uri}. Only HTTPS is allowed." if uri.scheme != 'https' ||
                                                                                [443, nil].exclude?(uri.port)
     raise UnableToDownload, "Error loading: #{uri}. Can't download from localhost." if uri.host.in?(LOCALHOSTS)
+
+    validate_resolved_ip!(uri.host)
+  end
+
+  def validate_resolved_ip!(host)
+    addresses = Resolv.getaddresses(host)
+
+    addresses.each do |addr|
+      ip = begin
+        IPAddr.new(addr)
+      rescue IPAddr::InvalidAddressError
+        next
+      end
+
+      if BLOCKED_CIDRS.any? { |cidr| cidr.include?(ip) }
+        raise UnableToDownload, "Can't download from private/reserved IP: #{addr}"
+      end
+    end
   end
 
   def conn(validate: Docuseal.multitenant?)


### PR DESCRIPTION
Related to #626 (which appears stale).

The current `DownloadUtils.validate_uri!` only blocks a fixed list of localhost hostname strings. Two bypasses exist:

1. **Private IP ranges not blocked**: `192.168.1.1`, `10.0.0.1`, `169.254.169.254` (AWS metadata), etc. are all allowed through.
2. **DNS rebinding**: A domain like `evil.com` resolving to `127.0.0.1` bypasses the hostname check since only the hostname string is compared, not the resolved IP.

Fix: After the existing hostname check, resolve the domain via DNS and verify all returned IPs are not in private/reserved CIDR ranges (RFC 1918, link-local, loopback, cloud metadata).

Also applies to the redirect callback in `conn()`.

`DownloadUtils` is called from template upload by URL, MCP tool, and submitter default value URLs — all authenticated endpoints, but still worth hardening.