### PR TITLE
Fix open redirect in sessions controller

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -27,8 +27,6 @@ class SessionsController < Devise::SessionsController
   def after_sign_in_path_for(...)
     if params[:redir].present?
       return console_redirect_index_path(redir: params[:redir]) if params[:redir].starts_with?(Docuseal::CONSOLE_URL)
-
-      return params[:redir]
     end
 
     super


### PR DESCRIPTION
After sign-in, if `params[:redir]` is present and does not start with the console URL, it is returned directly as the redirect destination. This allows an attacker to craft a login URL like:

```
/users/sign_in?redir=https://evil.com
```

After the user logs in, they get redirected to `evil.com`. This is a classic open redirect that can be used for phishing.

The console URL path is already handled correctly. This fix removes the fallback `return params[:redir]` so non-console external URLs are no longer followed.