### PR TITLE
Fix open redirect in templates share link controller

### DIFF
--- a/app/controllers/templates_share_link_controller.rb
+++ b/app/controllers/templates_share_link_controller.rb
@@ -10,7 +10,7 @@ class TemplatesShareLinkController < ApplicationController
 
     @template.update!(template_params)
 
-    if params[:redir].present?
+    if params[:redir].present? && params[:redir].start_with?('/')
       redirect_to params[:redir]
     else
       head :ok


### PR DESCRIPTION
Same issue as the sessions controller open redirect but in `TemplatesShareLinkController#create`. The `redir` param is used directly in `redirect_to` without validation.

Fix: Only allow relative paths (starting with `/`).