### PR TITLE
Unhide strikethrough field type in template builder

### DIFF
--- a/app/javascript/template_builder/field_type.vue
+++ b/app/javascript/template_builder/field_type.vue
@@ -164,7 +164,7 @@ export default {
       }
     },
     skipTypes () {
-      return ['heading', 'datenow', 'strikethrough']
+      return ['heading', 'datenow']
     },
     fieldIconsSorted () {
       if (this.fieldTypes.length) {

--- a/app/javascript/template_builder/fields.vue
+++ b/app/javascript/template_builder/fields.vue
@@ -574,7 +574,7 @@ export default {
       }, {})
     },
     skipTypes () {
-      return ['heading', 'datenow', 'strikethrough']
+      return ['heading', 'datenow']
     },
     fieldIconsSorted () {
       if (this.fieldTypes.length) {


### PR DESCRIPTION
### Problem

The `strikethrough` field type is fully implemented end-to-end:

- Drawing in the template builder ([builder.vue](https://github.com/docusealco/docuseal/blob/master/app/javascript/template_builder/builder.vue))
- Rendering at sign time ([submission_form/area.vue:266](https://github.com/docusealco/docuseal/blob/master/app/javascript/submission_form/area.vue#L266))
- Rendering in the completed submission view ([submissions/_value.html.erb](https://github.com/docusealco/docuseal/blob/master/app/views/submissions/_value.html.erb))
- Server-enforced non-editability ([submit_values.rb:10](https://github.com/docusealco/docuseal/blob/master/lib/submitters/submit_values.rb#L10) — listed in `NONEDITABLE_FIELD_TYPES`)
- i18n strings in 14 languages
- Audit trail integration

However, it's filtered out of the default field picker by the `skipTypes` array in both [field_type.vue:167](https://github.com/docusealco/docuseal/blob/master/app/javascript/template_builder/field_type.vue#L167) and [fields.vue:577](https://github.com/docusealco/docuseal/blob/master/app/javascript/template_builder/fields.vue#L577). Without that filter, end-users have no way to discover the feature short of reading source.

### Use case

Counter-offer markup workflows: the template author strikes through clauses they're countering and places initials boxes next to each strike for the signer to acknowledge each modification. The strikethrough is author-only and non-editable by signers — already correctly enforced by `NONEDITABLE_FIELD_TYPES`. The feature works exactly right for this; it just needs to be visible in the picker.

### Change

Remove `'strikethrough'` from `skipTypes` in both files. The other two filtered types (`heading`, `datenow`) remain hidden as before.

### Diff size

2 files, +2 −2 lines.