### PR TITLE
docs: fix README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ DocuSeal is an open source platform that provides secure and efficient digital d
 - Company logo and white-label
 - User roles
 - Automated reminders
-- Invitation and identify verification via SMS
+- Invitation and identity verification via SMS
 - Conditional fields and formulas
 - Bulk send with CSV, XLSX spreadsheet import
 - SSO / SAML
@@ -74,7 +74,7 @@ DocuSeal is an open source platform that provides secure and efficient digital d
 docker run --name docuseal -p 3000:3000 -v.:/data docuseal/docuseal
 ```
 
-By default DocuSeal docker container uses an SQLite database to store data and configurations. Alternatively, it is possible use PostgreSQL or MySQL databases by specifying the `DATABASE_URL` env variable.
+By default DocuSeal docker container uses an SQLite database to store data and configurations. Alternatively, it is possible to use PostgreSQL or MySQL databases by specifying the `DATABASE_URL` env variable.
 
 #### Docker Compose
 


### PR DESCRIPTION
## Summary
- Fix two README wording typos in the Pro Features and Docker sections

## Verification
- Checked all non-code-fence local Markdown links resolve
- `git diff --check`