### PR TITLE
feat: show plaintext TOTP secret during 2FA setup

### DIFF
--- a/app/views/mfa_setup/_form.html.erb
+++ b/app/views/mfa_setup/_form.html.erb
@@ -5,6 +5,10 @@
   <div>
     <%== RQRCode::QRCode.new(@provision_url).as_svg(viewbox: true, svg_attributes: { class: 'md:w-80 md:h-80 my-4 mx-auto' }) %>
   </div>
+  <div class="text-center my-2">
+    <p class="text-sm text-base-content/70"><%= t('or_enter_this_key_manually') %>:</p>
+    <code class="font-mono text-sm select-all bg-base-200 px-2 py-1 rounded break-all"><%= current_user.otp_secret %></code>
+  </div>
   <div class="form-control my-6 space-y-2">
     <%= f.text_field :otp_attempt, required: true, placeholder: 'XXX-XXX', class: 'base-input text-center' %>
     <span>

--- a/config/locales/i18n.yml
+++ b/config/locales/i18n.yml
@@ -285,6 +285,7 @@ en: &en
   confirm_password: Confirm new password
   save_password_and_sign_in: Save password and Sign in
   use_an_authenticator_mobile_app_like_google_authenticator_or_1password_to_scan_the_qr_code_below: Use an authenticator mobile app like Google Authenticator or 1Password to scan the QR code below.
+  or_enter_this_key_manually: Or enter this key manually
   remove_2fa: Remove 2FA
   setup_2fa: Setup 2FA
   2fa_has_been_configured: 2FA has been configured.


### PR DESCRIPTION
Closes #586

## Summary
Displays the raw TOTP secret as selectable text alongside the QR code during 2FA setup.

Helps users who cannot scan QR codes (no camera, remote desktop, screen readers) or prefer to manually enter keys into password managers.

## Changes
- `app/views/mfa_setup/_form.html.erb` — adds `<code>` block with `current_user.otp_secret` below the QR code
- `config/locales/i18n.yml` — adds `or_enter_this_key_manually` English translation key

## Test plan
- [ ] TOTP secret appears below QR code on 2FA setup page
- [ ] Text is selectable/copyable
- [ ] Manually entering the secret into an authenticator app works