### PR TITLE
feat: add submission counts to templates view (closes #617)

### DIFF
--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -67,7 +67,7 @@ class Template < ApplicationRecord
   has_many :schema_documents, ->(e) { where(uuid: e.schema.pluck('attachment_uuid')) },
            class_name: 'ActiveStorage::Attachment', dependent: :destroy, as: :record, inverse_of: :record
 
-  has_many :submissions, dependent: :destroy
+  has_many :submissions, dependent: :destroy, counter_cache: :submissions_count
   has_many :template_sharings, dependent: :destroy
   has_many :template_accesses, dependent: :destroy
   has_many :dynamic_documents, dependent: :destroy

--- a/app/models/template_folder.rb
+++ b/app/models/template_folder.rb
@@ -51,4 +51,11 @@ class TemplateFolder < ApplicationRecord
   def default?
     name == DEFAULT_NAME
   end
+
+  def submissions_count
+    @submissions_count ||=
+      Rails.cache.fetch("#{cache_key_with_version}/submissions_count", expires_in: 5.minutes) do
+        active_templates.sum(:submissions_count) + subfolders.sum(&:submissions_count)
+      end
+  end
 end

--- a/app/views/template_folders/_folder.html.erb
+++ b/app/views/template_folders/_folder.html.erb
@@ -3,10 +3,18 @@
   <% if !is_long %>
     <%= svg_icon('folder', class: 'w-6 h-6') %>
   <% end %>
-  <div class="text-lg font-semibold mt-1" style="overflow: hidden; display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: <%= is_long ? 2 : 1 %>;">
-    <% if is_long %>
-      <%= svg_icon('folder', class: 'w-6 h-6 inline') %>
+  <div class="text-lg font-semibold mt-1 flex items-center justify-between" style="overflow: hidden; display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: <%= is_long ? 2 : 1 %>;">
+    <div>
+      <% if is_long %>
+        <%= svg_icon('folder', class: 'w-6 h-6 inline') %>
+      <% end %>
+      <%= folder.name %>
+    </div>
+    <% if folder.submissions_count > 0 %>
+      <span class="text-xs text-base-content/60 flex items-center space-x-1">
+        <%= svg_icon('file_text', class: 'w-3 h-3') %>
+        <span><%= folder.submissions_count %></span>
+      </span>
     <% end %>
-    <%= folder.name %>
   </div>
 </a>

--- a/app/views/templates/_template.html.erb
+++ b/app/views/templates/_template.html.erb
@@ -24,6 +24,11 @@
             <%= svg_icon('folder', class: 'w-4 h-4 flex-shrink-0') %>
             <span class="truncate"><%= template.folder.full_name %></span>
           </span>
+        <% else %>
+          <span class="flex items-center space-x-1 w-1/2 justify-end">
+            <%= svg_icon('file_text', class: 'w-4 h-4') %>
+            <span><%= template.submissions_count %></span>
+          </span>
         <% end %>
       </p>
     </div>

--- a/db/migrate/20260510100000_add_submissions_count_to_templates.rb
+++ b/db/migrate/20260510100000_add_submissions_count_to_templates.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class AddSubmissionsCountToTemplates < ActiveRecord::Migration[7.2]
+  def up
+    add_column :templates, :submissions_count, :integer, default: 0, null: false
+
+    # Backfill existing counts
+    execute <<~SQL.squish
+      UPDATE templates
+      SET submissions_count = (
+        SELECT COUNT(*)
+        FROM submissions
+        WHERE submissions.template_id = templates.id
+      )
+    SQL
+  end
+
+  def down
+    remove_column :templates, :submissions_count
+  end
+end

--- a/spec/system/dashboard_spec.rb
+++ b/spec/system/dashboard_spec.rb
@@ -36,6 +36,15 @@ RSpec.describe 'Dashboard Page' do
       expect(page).to have_link('Create', href: new_template_path)
     end
 
+    it 'shows submission count for templates' do
+      create(:submission, template: templates[0])
+
+      visit root_path
+
+      expect(page).to have_content('0')
+      expect(page).to have_content('1')
+    end
+
     it 'initializes the template creation process' do
       click_link 'Create'
 


### PR DESCRIPTION
Closes #617

## What's changed
- Added `submissions_count` counter cache column to the `templates` table via migration (with backfill)
- Added `submissions_count` method to `TemplateFolder` that aggregates counts from all nested templates and subfolders
- Updated `_template.html.erb` to display submission count next to each template (non-archived only)
- Updated `_folder.html.erb` to display aggregated submission count next to folder icon
- Added system spec coverage for the new counts display