### PR TITLE
docs: add Sealos deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ DocuSeal is an open source platform that provides secure and efficient digital d
 
 ## Deploy
 
-|Heroku|Railway|
-|:--:|:---:|
-| [<img alt="Deploy on Heroku" src="https://www.herokucdn.com/deploy/button.svg" height="40">](https://heroku.com/deploy?template=https://github.com/docusealco/docuseal-heroku) | [<img alt="Deploy on Railway" src="https://railway.app/button.svg" height="40">](https://railway.com/deploy/IGoDnc?referralCode=ruU7JR)|
-|**DigitalOcean**|**Render**|
-| [<img alt="Deploy on DigitalOcean" src="https://www.deploytodo.com/do-btn-blue.svg" height="40">](https://cloud.digitalocean.com/apps/new?repo=https://github.com/docusealco/docuseal-digitalocean/tree/master&refcode=421d50f53990) | [<img alt="Deploy to Render" src="https://render.com/images/deploy-to-render-button.svg" height="40">](https://render.com/deploy?repo=https://github.com/docusealco/docuseal-render)
+|Heroku|Railway|Sealos|
+|:--:|:---:|:---:|
+| [<img alt="Deploy on Heroku" src="https://www.herokucdn.com/deploy/button.svg" height="40">](https://heroku.com/deploy?template=https://github.com/docusealco/docuseal-heroku) | [<img alt="Deploy on Railway" src="https://railway.app/button.svg" height="40">](https://railway.com/deploy/IGoDnc?referralCode=ruU7JR) | [<img alt="Deploy on Sealos" src="https://sealos.io/Deploy-on-Sealos.svg" height="40">](https://sealos.io/products/app-store/docuseal/) |
+|**DigitalOcean**|**Render**||
+| [<img alt="Deploy on DigitalOcean" src="https://www.deploytodo.com/do-btn-blue.svg" height="40">](https://cloud.digitalocean.com/apps/new?repo=https://github.com/docusealco/docuseal-digitalocean/tree/master&refcode=421d50f53990) | [<img alt="Deploy to Render" src="https://render.com/images/deploy-to-render-button.svg" height="40">](https://render.com/deploy?repo=https://github.com/docusealco/docuseal-render) | |
 
 #### Docker
 


### PR DESCRIPTION
## Summary

This PR adds Sealos to the existing deployment options table in the README.

## Why

This gives users who already use Sealos a one-click deployment path without changing the application code or default installation flow.

## Validation

- Sealos template: https://sealos.io/products/app-store/docuseal
- App image: `docuseal/docuseal:3.1.1`
- Tested deployment: 2026-08-05
- Browser smoke covered first-run setup, sign-in, and representative navigation.
- PostgreSQL data and `/data/docuseal` use persistent storage; optional S3-compatible storage is available for uploaded files.
- Runtime log scans ended with zero active failures, and the verification deployment was fully cleaned up.
- The template URL and button SVG both return HTTP 200.
- This is a docs-only change with no runtime behavior changes.

## Maintenance

I can help maintain this deployment path and follow up if the Sealos template or README entry needs updates.
